### PR TITLE
Add versioned AWS S3 deployment, separate npm and GitHub release jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           root: .
           paths:
             - dist
-  release:
+  release-to-github:
     docker:
       - image: circleci/node:latest
     steps:
@@ -50,11 +50,41 @@ jobs:
       - run:
           name: Release to GitHub
           command: npm run release-to-github
+  publish-on-npm:
+    docker:
+      - image: circleci/node:latest
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
       - run:
           name: Publish on npm
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             npm publish --access=public
+  deploy-to-aws:
+    docker:
+      - image: circleci/python:latest
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install AWS CLI
+          command: pip install awscli --upgrade --user
+      - run:
+          name: Create versioned directory
+          command: |
+            PACKAGE_VERSION=`python -c "import json; print(json.load(open('package.json'))[u'version'])"`
+            mkdir -p versioned/latest
+            cp -a dist/. versioned/latest
+            mkdir -p versioned/${PACKAGE_VERSION}
+            cp -a dist/. versioned/${PACKAGE_VERSION}
+      - run:
+          name: Deploy versioned directory to S3
+          command: |
+            export PATH=~/.local/bin:$PATH
+            aws s3 sync versioned s3://tw-frontend-assets/icons --acl public-read
   demo:
     docker:
       - image: circleci/node:latest
@@ -88,7 +118,21 @@ workflows:
       - build-package:
           requires:
             - build
-      - release:
+      - release-to-github:
+          requires:
+            - test
+            - build-package
+          filters:
+            branches:
+              only: master
+      - publish-on-npm:
+          requires:
+            - test
+            - build-package
+          filters:
+            branches:
+              only: master
+      - deploy-to-aws:
           requires:
             - test
             - build-package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.8.0
+## Adds versioned deployment to AWS
+
+The assets will be deployed to:
+
+<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/sprite.svg> (SVG sprite itself)
+<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/svg-icon-sprite.js> (sprite string script)
+<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/svg-icon-sprite-version.js> (sprite version script)
+<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/icons.min.css> (styles)
+
+Where `0.8.0` is the version or `latest`.
+
 # v0.7.0
 ## Adds controls for modifying icon sizes and color in demo
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ The SVG icon sprite and demo are built using [create-svg-icon-sprite](https://gi
 
 [A helpful general guide for SVG icon sprites - CSSTricks](https://css-tricks.com/svg-sprites-use-better-icon-fonts/)
 
+### CDN
+
+The assets are available at:
+
+<https://daw291njkc3ao.cloudfront.net/icons/{version}/sprite.svg> (SVG sprite itself)
+<https://daw291njkc3ao.cloudfront.net/icons/{version}/svg-icon-sprite.js> (sprite string script)
+<https://daw291njkc3ao.cloudfront.net/icons/{version}/svg-icon-sprite-version.js> (sprite version script)
+<https://daw291njkc3ao.cloudfront.net/icons/{version}/icons.min.css> (styles)
+
+Where `{version}` is either the package version or `latest`.
+
 ### Installation
 
 `npm install --save @transferwise/icons`

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
-const iconSprite = require('./dist/svg-icon-sprite');
+const svgIconSprite = require('./dist/svg-icon-sprite');
+const svgIconSpriteVersion = require('./dist/svg-icon-sprite-version');
 
 module.exports = {
-  iconSprite,
+  svgIconSprite,
+  svgIconSpriteVersion,
 };
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@transferwise/icons",
-  "version": "0.6.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
       "dev": true
     },
     "acorn-jsx": {
@@ -405,9 +405,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "create-svg-icon-sprite": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/create-svg-icon-sprite/-/create-svg-icon-sprite-1.1.0.tgz",
-      "integrity": "sha512-Y3SaTBHXqTDDdsch1Ra4PPB8iIr7p6zIh4kRRbgn9o30D2UkzB8gE56JmqFyKb4kxSKAQyqxeXLIvzzaOtBiCw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-svg-icon-sprite/-/create-svg-icon-sprite-1.1.1.tgz",
+      "integrity": "sha512-UOE3BcuOQUtPgP+lKiNqiiln4i956QWWmNg6y3oJKG9PUjkVFQxKFLP8QwFUL6sAIabTZOHoqrCOGb6nerRj8w==",
       "requires": {
         "ejs": "2.5.7",
         "mkdirp": "0.5.1",
@@ -609,9 +609,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.2.tgz",
-      "integrity": "sha512-LSas5vsuA6Q4nEdf9wokY5/AJYXry98i0IzXsv49rYsgDGDNDPbqAYR1Pe23iFxygfbGZNR/5VrHXBCh2BhvUQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -619,9 +619,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.15.0.tgz",
-      "integrity": "sha512-zEO/Z1ZUxIQ+MhDVKkVTUYpIPDTEJLXGMrkID+5v1NeQHtCz6FZikWuFRgxE1Q/RV2V4zVl1u3xmpPADHhMZ6A==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.16.0.tgz",
+      "integrity": "sha512-YVXV4bDhNoHHcv0qzU4Meof7/P26B4EuaktMi5L1Tnt52Aov85KmYA8c5D+xyZr/BkhvwUqr011jDSD/QTULxg==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
@@ -639,11 +639,11 @@
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.1.0",
+        "globals": "11.3.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
         "inquirer": "3.3.0",
-        "is-resolvable": "1.0.1",
+        "is-resolvable": "1.1.0",
         "js-yaml": "3.10.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
@@ -656,7 +656,7 @@
         "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.2",
@@ -811,7 +811,7 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.4.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -1111,9 +1111,9 @@
       }
     },
     "globals": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-      "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+      "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
       "dev": true
     },
     "globby": {
@@ -1388,9 +1388,9 @@
       }
     },
     "is-resolvable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.1.tgz",
-      "integrity": "sha512-y5CXYbzvB3jTnWAZH1Nl7ykUWb6T3BcTs56HUruwBf8MhF56n1HWqhDWnVFo8GHrUPDgvUUNVhrc2U8W7iqz5g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
@@ -1698,7 +1698,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memorystream": {
@@ -1720,9 +1720,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1774,7 +1774,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -1907,7 +1907,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -2031,7 +2031,7 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
       "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
       "requires": {
-        "es6-promise": "4.2.2",
+        "es6-promise": "4.2.4",
         "extract-zip": "1.6.6",
         "fs-extra": "1.0.0",
         "hasha": "2.2.0",
@@ -2360,7 +2360,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "request-progress": {
@@ -2477,9 +2477,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2887,9 +2887,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@transferwise/icons",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TransferWise SVG icons",
   "main": "index.js",
   "scripts": {
     "start": "npm-run-all build demo:build",
-    "build": "npm-run-all clean build-sprite build-styles build-script",
+    "build": "npm-run-all clean build-sprite build-styles build-script build-version-script",
     "clean": "rimraf dist",
     "build-sprite": "node scripts/createSprite",
     "build-styles": "cleancss -o dist/icons.min.css styles.css",
     "build-script": "node scripts/buildScript",
+    "build-version-script": "node scripts/buildVersionScript",
     "build-demo": "node scripts/buildDemo",
     "deploy-demo": "gh-pages -d demo",
     "test": "npm-run-all check-release-to-github lint",

--- a/scripts/buildVersionScript.js
+++ b/scripts/buildVersionScript.js
@@ -1,0 +1,3 @@
+const { buildVersionScript } = require('create-svg-icon-sprite');
+
+buildVersionScript();


### PR DESCRIPTION
**[WAITING FOR AWS CREDENTIALS FROM INFRA, BUT CAN BE REVIEWED]**

# v0.8.0
## Adds versioned deployment to AWS

The assets will be deployed to:

<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/sprite.svg> (SVG sprite itself)
<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/svg-icon-sprite.js> (sprite string script)
<https://daw291njkc3ao.cloudfront.net/icons/0.8.0/icons.min.css> (styles)

Where `0.8.0` is the version or `latest`.