### PR TITLE
Fix circle setup to include react components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Build
+          command: npm run build
+      - run:
           name: Publish on npm
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           root: .
           paths:
             - dist
+            - react
   release-to-github:
     docker:
       - image: circleci/node:latest
@@ -57,9 +58,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Build
-          command: npm run build
       - run:
           name: Publish on npm
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v0.11.1
+## Fixes react folder missing from NPM package
+
 # v0.11.0
 ## Adds `pin` icon
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "TransferWise SVG icons",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The published NPM package doesn't contain the new react components. I think it's because Circle doesn't run build before publishing. Added the build step to Circle's `publish-on-npm` job.