### PR TITLE
Increase weight of Close icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v1.0.0
-## Update Close icon
+## Increases weight of Close icon
 
 Change weight of Close icon to match most common usage on all platforms. We're aware of the inconsistency it brings to the current set, it's an interim solution while we redesign all icons.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.0.0
+## Update Close icon
+
+Change weight of Close icon to match most common usage on all platforms. We're aware of the inconsistency it brings to the current set, it's an interim solution while we redesign all icons.
+
 # v0.14.0
 ## Move dependencies to devDependencies
 

--- a/icons/close.svg
+++ b/icons/close.svg
@@ -1,1 +1,1 @@
-<svg id="artwork" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>close</title><polygon points="21.85 2.85 21.15 2.15 12 11.29 2.85 2.15 2.15 2.85 11.29 12 2.15 21.15 2.85 21.85 12 12.71 21.15 21.85 21.85 21.15 12.71 12 21.85 2.85"/></svg>
+<svg id="artwork" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>close</title><polygon points="5.5 4 4 5.5 10.5 12 4 18.5 5.5 20 12 13.5 18.5 20 20 18.5 13.5 12 20 5.5 18.5 4 12 10.5 5.5 4"/></svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "0.13.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "TransferWise SVG icons",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# v1.0.0
## Increases weight of Close icon

Change weight of Close icon to match most common usage on all platforms. We're aware of the inconsistency it brings to the current set, it's an interim solution while we redesign all icons.

The breaking release is due to the icon change being distinctively different than the rest, so it should enforce a more careful check of the usage.

![change](https://user-images.githubusercontent.com/782754/60517911-61408c80-9cd8-11e9-829c-7830562e03ce.gif)
