### PR TITLE
fix: angular js icon component declaration with suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v2.0.0-beta.3
+## Fix angularJS component names
+The `-icon` suffix was missing for each angular icon, when they were added to the `twIconsModule` angular module. 
+Now the module declaration includes the `Icon` suffix at the end
+```js
+.component("tw${icon.componentName}Icon", ${icon.componentName}IconComponent)
+...
+```
+
 # v2.0.0-beta.2
 ## Add angularJS support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "description": "TransferWise SVG icons",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/scripts/utils/angularjs-components.ts
+++ b/scripts/utils/angularjs-components.ts
@@ -65,7 +65,7 @@ export const generateAngularJsIconModuleContent = (icons: IconsMap, targetDir: s
       `import { ${icon.componentName}IconComponent } from "./components/${key}-icon.component"`,
     );
     moduleComponents.push(
-      `.component("tw${icon.componentName}", ${icon.componentName}IconComponent)`,
+      `.component("tw${icon.componentName}Icon", ${icon.componentName}IconComponent)`,
     );
   });
 


### PR DESCRIPTION
## ❓ Context
The `-icon` suffix was missing for each angular icon, when they were added to the `twIconsModule` angular module. 
Now the module declaration includes the `Icon` suffix at the end
```js
.component("tw${icon.componentName}Icon", ${icon.componentName}IconComponent)
...
```

and in the template, components can be used like this now
```html
<tw-activity-icon size="24" filled="true"></tw-activity-icon>

// instead of this
<tw-activity size="24" filled="true"></tw-activity>
```


## 🚀 Changes
- add suffix to angular component declarations

## 💬 Considerations


## ✅ Checklist

- [x] The package version is bumped according to README in `package.json`, `package-lock.json`, and `CHANGELOG.md`
