### PR TITLE
feat: add common tw-icon classname to angular template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.0.0-beta.5
+
+## Add common `tw-icon` class name to angular component template
+
+Add `tw-icon` class, that was missing from the template that is used to generate all the angularJS commponents. 
+Now each angularJS component will have the general class name and the scoped one: e.g. `tw-icon tw-icon-activity`
+
 # v2.0.0-beta.4
 
 ## Add Activity Category icons

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "TransferWise SVG icons",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/scripts/utils/angularjs-components.ts
+++ b/scripts/utils/angularjs-components.ts
@@ -8,7 +8,7 @@ const getTemplate = (
 ): string => {
   if (hasFillVariant) {
     return `
-<div class="tw-icon-${icon.name}" ng-if="!$ctrl.filled" ng-switch="$ctrl.size">
+<div class="tw-icon tw-icon-${icon.name}" ng-if="!$ctrl.filled" ng-switch="$ctrl.size">
   <svg ng-switch-when="16" width="16" height="16" fill="currentColor">
     ${svgContent.outline[16].angular}
   </svg>


### PR DESCRIPTION


## ❓ Context
Add `.tw-icon` class, that was missing from the template that is used to generate all the angularJS commponents. 

Now each angularJS component will have the general class name and the scoped one: 

**E.g.** 
```css
tw-icon tw-icon-activity
```

## ✅ Checklist

- [x] The package version is bumped according to README in `package.json`, `package-lock.json`, and `CHANGELOG.md`
