### PR TITLE
fix: add missing class names to angularjs templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.0.0-beta.6
+
+## Add missing `tw-icon` class names to angular component templates
+
 # v2.0.0-beta.5
 
 ## Add common `tw-icon` class name to angular component template

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "TransferWise SVG icons",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/scripts/utils/angularjs-components.ts
+++ b/scripts/utils/angularjs-components.ts
@@ -16,7 +16,7 @@ const getTemplate = (
     ${svgContent.outline[24].angular}
   </svg>
 </div>
-<div class="tw-icon-${icon.name}" ng-if="$ctrl.filled" ng-switch="$ctrl.size">
+<div class="tw-icon tw-icon-${icon.name}" ng-if="$ctrl.filled" ng-switch="$ctrl.size">
   <svg ng-switch-when="16" width="16" height="16" fill="currentColor">
     ${svgContent.fill[16].angular}
   </svg>
@@ -27,7 +27,7 @@ const getTemplate = (
   }
 
   return `
-  <div class="tw-icon-${icon.name}" ng-if="!$ctrl.filled" ng-switch="$ctrl.size">
+  <div class="tw-icon tw-icon-${icon.name}" ng-if="!$ctrl.filled" ng-switch="$ctrl.size">
     <svg ng-switch-when="16" width="16" height="16" fill="currentColor">
       ${svgContent.outline[16].angular}
     </svg>


### PR DESCRIPTION
Fix of previous PR