### PR TITLE
add  prop for React icon components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.4.0
+
+## Add `data-testid` prop for React icon components
+
 # v2.3.0
 
 ## Generic icon component for Angular set

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm install @transferwise/icons
 ```ts
 import { Bank as BankIcon } from '@transferwise/icons';
 
-const YourComponent = () => <BankIcon size={24} filled />;
+const YourComponent = () => <BankIcon size={24} filled data-testid="bank-icon" />;
 ```
 
 will result in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transferwise/icons",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "TransferWise SVG icons",
   "main": "lib/index.js",
   "module": "lib/index.es.js",

--- a/scripts/utils/react-components.ts
+++ b/scripts/utils/react-components.ts
@@ -18,18 +18,20 @@ export interface ${icon.componentName}IconProps {
   ${hasFillVariant ? `filled?: boolean;` : ''}
   className?: string;
   title?: string;
+  ['data-testid']?: string;
 }
 
 export const ${icon.componentName}: FunctionComponent<${
     icon.componentName
   }IconProps> = ({ size = 16, className = undefined, title = undefined ${
     hasFillVariant ? `, filled = false` : ''
-  } }) => {
+  }, ...restProps }) => {
   return (
     <span
       className={\`tw-icon tw-icon-${icon.name} \${className ? className : ''}\`}
       aria-hidden={!title ? 'true' : undefined}
       role={!title ? 'presentation' : undefined}
+      data-testid={restProps['data-testid']}
     >
       <svg width={String(size)} height={String(size)} fill="currentColor">
         { Number(size) === 16 ${hasFillVariant ? '&& filled === false' : ''} && (


### PR DESCRIPTION
## ❓ Context

I've thought that this makes sense, peeps have asked about it as well https://github.com/transferwise/send-flow/pull/1135#discussion_r452631018

## 🚀 Changes

Expose `data-testtid` prop for all react icon components.

## 💬 Considerations
<!-- additional info for reviewing, discussion topics -->

## ✅ Checklist

- [x] The package version is bumped according to README.md in `package.json`, and `CHANGELOG.md`
