### PR TITLE
Export a lookup map from name of icon to React component

### DIFF
--- a/src/build-scripts/utils/react-components.ts
+++ b/src/build-scripts/utils/react-components.ts
@@ -68,6 +68,24 @@ export const ${icon.componentName}: FunctionComponent<${
 `;
 };
 
+export const generateIconLookup = (icons: IconsMap, targetDir: string): void => {
+  const output: string[] = [GENERATED_CODE_COMMENT];
+
+  // Imports
+  Object.values(icons).forEach(icon => {
+    output.push(`import { ${icon.componentName} } from './components/${icon.name}';`);
+  });
+
+  // Map
+  output.push('export default {');
+  Object.values(icons).forEach(icon => {
+    output.push(`  '${icon.name}': ${icon.componentName},`);
+  });
+  output.push('}');
+
+  writeFile(`${targetDir}/lookup.ts`, output.join('\n'));
+};
+
 export const generateAdditionalReactFiles = (icons: IconsMap, targetDir: string): void => {
   // Create index file that exports all the icons in the components folder
   const exportComponents = Object.keys(icons)
@@ -76,11 +94,20 @@ export const generateAdditionalReactFiles = (icons: IconsMap, targetDir: string)
   writeFile(`${targetDir}/components/index.ts`, exportComponents);
 
   // Create index file in ./${targetDir} folder for exporting everyhting from ./${targetDir}/components
-  writeFile(`${targetDir}/index.ts`, `${GENERATED_CODE_COMMENT}\nexport * from "./components";`);
+  writeFile(
+    `${targetDir}/index.ts`,
+    [
+      GENERATED_CODE_COMMENT,
+      `export * from "./components";`,
+      `export { default as lookup } from './lookup';`,
+    ].join('\n'),
+  );
 
   // Create types file that exports common types
   writeFile(
     `${targetDir}/types.ts`,
     `${GENERATED_CODE_COMMENT}\nexport type IconSize = "16" | "24" | 16 | 24;`,
   );
+
+  generateIconLookup(icons, targetDir);
 };


### PR DESCRIPTION
## ❓ Context

In [navigation-ui](https://github.com/transferwise/navigation-ui) we don't know which icons will be used at build time, only at runtime. We maintain [a map of supported icons](https://github.com/transferwise/navigation-ui/blob/master/src/util/icons/DynamicIcon.tsx#L29) but this requires a patch and rollout whenever somebody wants to use a new icon.

## 🚀 Changes

This PR adds a `lookup` export which contains a map from icon name to React component. It allows navigation-ui and dynamic forms to find a React icon purely by the icon name, without knowing what these icons might be at build time.

When used, the consumer will bundle all icons into their app. If it isn't used, the icons remain tree-shakeable and only the icons that are used will be bundled.

The generated code looks like this:

```ts
// This is an automatically generetad file, please don't edit it
import { Ach } from './components/ach';
import { Activity } from './components/activity';
// ...
import { Verified } from './components/verified';
import { Whatsapp } from './components/whatsapp';
export default {
  ach: Ach,
  activity: Activity,
  // ...
  verified: Verified,
  whatsapp: Whatsapp,
};
```

## 💬 Considerations

Using the lookup adds around 40kb (gzipped) extra to a bundle, due to the extra icons that are included.

Is there a better way?

## ✅ Checklist

- [ ] Make the PR title meaningful
- [ ] The package version is bumped according to README.md in `package.json`, and `CHANGELOG.md`
